### PR TITLE
Added CanFulfillIntentRequest feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "4.3.2"
   - "6.10"
+  - "8.10"
 script: ./run-ci.sh
 notifications:
   webhooks:

--- a/docs/canFulfillIntentRequest.rst
+++ b/docs/canFulfillIntentRequest.rst
@@ -1,0 +1,52 @@
+.. _canFulfillIntentRequest:
+
+CanFulfillIntentRequest
+=======================
+
+Name-free interaction enables customers to interact with Alexa without invoking a specific skill by name, which helps facilitate greater interaction with Alexa because customers do not always know which skill is appropriate.
+
+When Alexa receives a request from a customer without a skill name, such as "Alexa, play relaxing sounds with crickets," Alexa looks for skills that might fulfill the request. Alexa determines the best choice among eligible skills and hands the request to the skill.
+
+To make your skill more discoverable for name-free interaction, you can implement the the `CanFulfillIntentRequest <https://developer.amazon.com/docs/custom-skills/quick-start-canfulfill-intent-request.html>`_ interface in your skill.
+
+In Voxa, you can take advantage of this feature by following this example:
+
+.. code-block:: javascript
+
+  skill.onIntent('NameIntent', (alexaEvent) => {
+    if (alexaEvent.request.isCanFulfillIntentRequest) {
+      const canFulfillIntent = {
+        canFulfill: 'YES',
+        slots: {},
+      };
+
+      _.each(alexaEvent.intent.params, (value, slotName) => {
+        canFulfillIntent.slots[slotName] = {
+          canUnderstand: 'YES',
+          canFulfill: 'YES',
+        };
+      });
+
+      return { canFulfillIntent };
+    }
+
+    return { to: 'nextState' };
+  });
+
+
+Voxa adds the property `isCanFulfillIntentRequest`_ to the request object when it identifies a `CanFulfillIntentRequest`_ request comes in the body request. Then, it automatically transforms it to an `IntentRequest` request to redirect the flow to the intent coming in the request. Then you should verify if this variable exists to respond to the Alexa service wether you're going to fulfill the request or not.
+
+If a skill has implemented canFulfillIntent according to the interface specification, the skill should be aware that the skill is not yet being asked to take action on behalf of the customer, and should not modify any state outside its scope, or have any observable interaction with its own calling functions or the outside world besides returning a value. Thus, the skill should not, at this point, perform any actions such as playing sound, turning lights on or off, providing feedback to the customer, committing a transaction, or making a state change.
+
+Therefore, if you have defined a custom `onSessionStarted`_ method, you should validate if a `CanFulfillIntentRequest`_ request comes in to not run the code the first time. If you accept to fulfill the intent, the second time this function is triggered you'll be able to run your code. You can validate it following this code snippet:
+
+.. code-block:: javascript
+
+  skill.onSessionStarted((alexaEvent) => {
+    if (!alexaEvent.request.isCanFulfillIntentRequest) {
+      const x = 1;
+      // MORE CODE...
+    }
+  });
+
+

--- a/docs/canFulfillIntentRequest.rst
+++ b/docs/canFulfillIntentRequest.rst
@@ -38,15 +38,15 @@ Voxa adds the property `isCanFulfillIntentRequest`_ to the request object when i
 
 If a skill has implemented canFulfillIntent according to the interface specification, the skill should be aware that the skill is not yet being asked to take action on behalf of the customer, and should not modify any state outside its scope, or have any observable interaction with its own calling functions or the outside world besides returning a value. Thus, the skill should not, at this point, perform any actions such as playing sound, turning lights on or off, providing feedback to the customer, committing a transaction, or making a state change.
 
-Therefore, if you have defined a custom `onSessionStarted`_ method, you should validate if a `CanFulfillIntentRequest`_ request comes in to not run the code the first time. If you accept to fulfill the intent, the second time this function is triggered you'll be able to run your code. You can validate it following this code snippet:
 
-.. code-block:: javascript
+Testing using ASK-CLI
+=====================
 
-  skill.onSessionStarted((alexaEvent) => {
-    if (!alexaEvent.request.isCanFulfillIntentRequest) {
-      const x = 1;
-      // MORE CODE...
-    }
-  });
+There are 2 options to test this feature manually. The first one is using the `Manual JSON` section of the `Test` tab in the developer portal. And the other one, is to use the `ASK CLI <https://developer.amazon.com/docs/custom-skills/implement-canfulfillintentrequest-for-name-free-interaction.html#test-the-skill-using-ask-cli>`_ from Amazon.
 
+You can just trigger this command in the console, and you'll get the result in your terminal:
+
+.. code-block:: bash
+
+  $ ask api invoke-skill --skill-id amzn1.ask.skill.[unique-value-here] --file /path/to/input/json --endpoint-region [endpoint-region-here]
 

--- a/docs/canFulfillIntentRequest.rst
+++ b/docs/canFulfillIntentRequest.rst
@@ -15,16 +15,10 @@ In Voxa, you can take advantage of this feature by following this example:
 
   skill.onCanFulfillIntentRequest((alexaEvent, reply) => {
     if (alexaEvent.intent.name === 'InfluencerIntent') {
-      reply.canFulfillIntent = {
-        canFulfill: 'YES',
-        slots: {},
-      };
+      reply.fulfillIntent('YES');
 
       _.each(alexaEvent.intent.params, (value, slotName) => {
-        reply.canFulfillIntent.slots[slotName] = {
-          canUnderstand: 'YES',
-          canFulfill: 'YES',
-        };
+        reply.fulfillSlot(slotName, 'YES', 'YES');
       });
     }
 

--- a/docs/canFulfillIntentRequest.rst
+++ b/docs/canFulfillIntentRequest.rst
@@ -13,28 +13,39 @@ In Voxa, you can take advantage of this feature by following this example:
 
 .. code-block:: javascript
 
-  skill.onIntent('NameIntent', (alexaEvent) => {
-    if (alexaEvent.request.isCanFulfillIntentRequest) {
-      const canFulfillIntent = {
+  skill.onCanFulfillIntentRequest((alexaEvent, reply) => {
+    if (alexaEvent.intent.name === 'InfluencerIntent') {
+      reply.canFulfillIntent = {
         canFulfill: 'YES',
         slots: {},
       };
 
       _.each(alexaEvent.intent.params, (value, slotName) => {
-        canFulfillIntent.slots[slotName] = {
+        reply.canFulfillIntent.slots[slotName] = {
           canUnderstand: 'YES',
           canFulfill: 'YES',
         };
       });
-
-      return { canFulfillIntent };
     }
 
-    return { to: 'nextState' };
+    return reply;
   });
 
 
-Voxa adds the property `isCanFulfillIntentRequest`_ to the request object when it identifies a `CanFulfillIntentRequest`_ request comes in the body request. Then, it automatically transforms it to an `IntentRequest` request to redirect the flow to the intent coming in the request. Then you should verify if this variable exists to respond to the Alexa service wether you're going to fulfill the request or not.
+Voxa offers the function `onCanFulfillIntentRequest`_ so you can implement it in your code to validate wether you're going to fulfill the request or not.
+
+Additionally, if you have several intents that you want to automatically fulfill, regardless of the slot values in the request, you can simply add an array of intents to the property: `defaultFulfillIntents`_ of the Voxa config file:
+
+.. code-block:: javascript
+
+  const defaulFulfillIntents = [
+    'NameIntent',
+    'PhoneIntent',
+  ];
+
+  const skill = new StateMachineSkill({ variables, views, defaultFulfillIntents });
+
+If Alexa sends an intent that you didn't register with this function, then you should implement the `onCanFulfillIntentRequest`_ method to handle it. Important: If you implement this method in your skill, you should always return the `reply`_ object.
 
 If a skill has implemented canFulfillIntent according to the interface specification, the skill should be aware that the skill is not yet being asked to take action on behalf of the customer, and should not modify any state outside its scope, or have any observable interaction with its own calling functions or the outside world besides returning a value. Thus, the skill should not, at this point, perform any actions such as playing sound, turning lights on or off, providing feedback to the customer, committing a transaction, or making a state change.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ Voxa is a framework that provides a way to organize a conversational experience 
 
 Why Voxa vs other frameworks
 ----------------------------
-Voxa provides a more robust framework for building Alexa skills, Cortana skills, or Google Assistant Actions. It provides a design pattern that wasn’t found in other frameworks. Critical to Voxa was providing a pluggable interface and supporting all of the latest platform features.
+Voxa provides a more robust framework for building Alexa skills. It provides a design pattern that wasn't found in other frameworks. Critical to Voxa was providing a pluggable interface and supporting all of the latest ASK features.
 
 Features
 --------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,11 +8,11 @@ Welcome to Voxa's documentation!
 
 Summary
 -------
-Voxa is an Alexa skill framework that provides a way to organize a skill into a state machine. Even the most complex voice user interface (VUI) can be represented through the state machine and it provides the flexibility needed to both be rigid when needed in specific states and flexible to jump around when allowing that also makes sense.  
+Voxa is a framework that provides a way to organize a conversational experience into a state machine. Even the most complex voice user interface (VUI) can be represented through the state machine and it provides the flexibility needed to both be rigid when needed in specific states and flexible to jump around states when needed.
 
 Why Voxa vs other frameworks
 ----------------------------
-Voxa provides a more robust framework for building Alexa skills.  It provides a design pattern that wasn’t found in other frameworks.   Critical to Voxa was providing a pluggable interface and supporting all of the latest ASK features.  
+Voxa provides a more robust framework for building Alexa skills, Cortana skills, or Google Assistant Actions. It provides a design pattern that wasn’t found in other frameworks. Critical to Voxa was providing a pluggable interface and supporting all of the latest platform features.
 
 Features
 --------

--- a/docs/reply.rst
+++ b/docs/reply.rst
@@ -12,12 +12,12 @@ The ``reply`` Object
   :param message: A message object
 
   .. js:function:: Reply.append(message)
-    
+
     Adds statements to the ``Reply``
-    
-    :param message: An object with keys ``ask``, ``tell``, ``say``, ``reprompt``, ``card`` or ``directives`` keys. Or another ``reply`` object
+
+    :param message: An object with keys ``ask``, ``tell``, ``say``, ``reprompt``, ``card``, ``canFulfillIntent`` or ``directives`` keys. Or another ``reply`` object
     :returns: the ``Reply`` object
 
   .. js:function:: Reply.toJSON()
-    
+
     :returns: An object with the proper format to send back to Alexa, with statements wrapped in SSML tags, cards, reprompts and directives

--- a/docs/reply.rst
+++ b/docs/reply.rst
@@ -15,7 +15,7 @@ The ``reply`` Object
 
     Adds statements to the ``Reply``
 
-    :param message: An object with keys ``ask``, ``tell``, ``say``, ``reprompt``, ``card``, ``canFulfillIntent`` or ``directives`` keys. Or another ``reply`` object
+    :param message: An object with keys ``ask``, ``tell``, ``say``, ``reprompt``, ``card``, or ``directives`` keys. Or another ``reply`` object
     :returns: the ``Reply`` object
 
   .. js:function:: Reply.toJSON()

--- a/docs/reply.rst
+++ b/docs/reply.rst
@@ -21,3 +21,13 @@ The ``reply`` Object
   .. js:function:: Reply.toJSON()
 
     :returns: An object with the proper format to send back to Alexa, with statements wrapped in SSML tags, cards, reprompts and directives
+
+  .. js:function:: Reply.fulfillIntent(canFulfill)
+
+    :param canFulfill: A string with possible values: YES | NO | MAYBE to fulfill request
+
+  .. js:function:: Reply.fulfillSlot(slotName, canUnderstand, canFulfill)
+
+    :param slotName: A string with the slot to fulfill
+    :param canUnderstand: A string with possible values: YES | NO | MAYBE that indicates slot understanding
+    :param canFulfill: A string with possible values: YES | NO that indicates slot fulfillment

--- a/lib/AlexaSkill.js
+++ b/lib/AlexaSkill.js
@@ -114,9 +114,13 @@ class AlexaSkill {
         }
       }
 
-
       if (this.getOnLaunchRequestHandlers().length === 0) {
         throw new Error('onLaunchRequest must be implemented');
+      }
+
+      if (alexaEvent.request.type === 'CanFulfillIntentRequest') {
+        alexaEvent.request.type = 'IntentRequest';
+        alexaEvent.request.isCanFulfillIntentRequest = true;
       }
 
       if (!this.requestHandlers[alexaEvent.request.type]) {

--- a/lib/AlexaSkill.js
+++ b/lib/AlexaSkill.js
@@ -95,9 +95,10 @@ class AlexaSkill {
       .catch(callback);
   }
 
-  execute(event) {
-    debug('Received new event: %s', JSON.stringify(event, null, 2));
-    const alexaEvent = new AlexaEvent(event);
+  execute(event, context) {
+    debug('Received new event: %s', JSON.stringify(event));
+    const alexaEvent = new AlexaEvent(event, context);
+
     return Promise.try(() => {
       // Validate that this AlexaRequest originated from authorized source.
       if (this.config.appIds) {

--- a/lib/AlexaSkill.js
+++ b/lib/AlexaSkill.js
@@ -22,6 +22,26 @@ class AlexaSkill {
     this.registerRequestHandlers();
     this.registerEvents();
 
+    this.onCanFulfillIntentRequest((alexaEvent, reply) => {
+      if (_.includes(this.config.defaultFulfillIntents, alexaEvent.intent.name)) {
+        const canFulfillIntent = {
+          canFulfill: 'YES',
+          slots: {},
+        };
+
+        _.each(alexaEvent.intent.params, (value, slotName) => {
+          canFulfillIntent.slots[slotName] = {
+            canUnderstand: 'YES',
+            canFulfill: 'YES',
+          };
+        });
+
+        reply.canFulfillIntent = canFulfillIntent;
+      }
+
+      return reply;
+    });
+
     this.onSessionEnded(() => ({ version: '1.0' }), true);
     this.onError((alexaEvent, error) => {
       debug('onError %s', error);
@@ -44,6 +64,7 @@ class AlexaSkill {
     return [
       'LaunchRequest',
       'IntentRequest',
+      'CanFulfillIntentRequest',
       'SessionEndedRequest',
       'AudioPlayer.PlaybackStarted',
       'AudioPlayer.PlaybackFinished',
@@ -119,11 +140,6 @@ class AlexaSkill {
         throw new Error('onLaunchRequest must be implemented');
       }
 
-      if (alexaEvent.request.type === 'CanFulfillIntentRequest') {
-        alexaEvent.request.type = 'IntentRequest';
-        alexaEvent.request.isCanFulfillIntentRequest = true;
-      }
-
       if (!this.requestHandlers[alexaEvent.request.type]) {
         throw new UnknownRequestType(alexaEvent.request.type);
       }
@@ -147,7 +163,7 @@ class AlexaSkill {
                 throw new OnSessionEndedError(_.get(alexaEvent, 'request.error'));
               }
 
-              if (!alexaEvent.session.new || alexaEvent.request.isCanFulfillIntentRequest) {
+              if (!alexaEvent.session.new) {
                 return null;
               }
               // call all onSessionStarted callbacks serially.

--- a/lib/AlexaSkill.js
+++ b/lib/AlexaSkill.js
@@ -147,7 +147,7 @@ class AlexaSkill {
                 throw new OnSessionEndedError(_.get(alexaEvent, 'request.error'));
               }
 
-              if (!alexaEvent.session.new) {
+              if (!alexaEvent.session.new || alexaEvent.request.isCanFulfillIntentRequest) {
                 return null;
               }
               // call all onSessionStarted callbacks serially.

--- a/lib/AlexaSkill.js
+++ b/lib/AlexaSkill.js
@@ -24,19 +24,11 @@ class AlexaSkill {
 
     this.onCanFulfillIntentRequest((alexaEvent, reply) => {
       if (_.includes(this.config.defaultFulfillIntents, alexaEvent.intent.name)) {
-        const canFulfillIntent = {
-          canFulfill: 'YES',
-          slots: {},
-        };
+        reply.fulfillIntent('YES');
 
         _.each(alexaEvent.intent.params, (value, slotName) => {
-          canFulfillIntent.slots[slotName] = {
-            canUnderstand: 'YES',
-            canFulfill: 'YES',
-          };
+          reply.fulfillSlot(slotName, 'YES', 'YES');
         });
-
-        reply.canFulfillIntent = canFulfillIntent;
       }
 
       return reply;

--- a/lib/Reply.js
+++ b/lib/Reply.js
@@ -54,7 +54,7 @@ class Reply {
     this.msg.reprompt = msg.reprompt || this.msg.reprompt;
     this.msg.card = msg.card || this.msg.card;
     this.msg.yield = this.msg.yield || !!(msg.ask || msg.tell);
-
+    this.msg.hasAnAsk = this.msg.hasAnAsk || !!msg.ask;
 
     msg.supportDisplayInterface = msg.supportDisplayInterface ||
       hasSupportForDisplay(this.alexaEvent);

--- a/lib/Reply.js
+++ b/lib/Reply.js
@@ -102,18 +102,7 @@ class Reply {
   }
 
   toJSON() {
-    const say = Reply.wrapSpeech(Reply.toSSML(this.msg.statements.join('\n')));
-    const reprompt = Reply.wrapSpeech(Reply.toSSML(this.msg.reprompt));
-    const directives = this.msg.directives;
-
-    const alexaResponse = {
-      outputSpeech: Reply.createSpeechObject(say),
-      card: this.msg.card,
-    };
-
-    if (!this.hasDirective('VideoApp.Launch')) {
-      alexaResponse.shouldEndSession = !!this.msg.terminate;
-    }
+    let alexaResponse;
 
     if (this.canFulfillIntent) {
       if (!_.includes(['YES', 'NO', 'MAYBE'], this.canFulfillIntent.canFulfill)) {
@@ -132,30 +121,47 @@ class Reply {
         }
       });
 
-      alexaResponse.canFulfillIntent = this.canFulfillIntent;
+      alexaResponse = {
+        canFulfillIntent: this.canFulfillIntent,
+      };
     } else if (this.alexaEvent.request.isCanFulfillIntentRequest) {
-      alexaResponse.canFulfillIntent = {
-        canFulfill: 'NO',
+      alexaResponse = {
+        canFulfillIntent: { canFulfill: 'NO' },
       };
-    }
+    } else {
+      const say = Reply.wrapSpeech(Reply.toSSML(this.msg.statements.join('\n')));
+      const reprompt = Reply.wrapSpeech(Reply.toSSML(this.msg.reprompt));
+      const directives = this.msg.directives;
 
-    if (reprompt) {
-      alexaResponse.reprompt = {
-        outputSpeech: Reply.createSpeechObject(reprompt),
+      alexaResponse = {
+        outputSpeech: Reply.createSpeechObject(say),
+        card: this.msg.card,
       };
-    }
 
-    if (directives && directives.length > 0) alexaResponse.directives = directives;
+      if (!this.hasDirective('VideoApp.Launch')) {
+        alexaResponse.shouldEndSession = !!this.msg.terminate;
+      }
+
+      if (reprompt) {
+        alexaResponse.reprompt = {
+          outputSpeech: Reply.createSpeechObject(reprompt),
+        };
+      }
+
+      if (directives && directives.length > 0) alexaResponse.directives = directives;
+    }
 
     const returnResult = {
       version: '1.0',
       response: alexaResponse,
     };
 
-    if (this.session && !_.isEmpty(this.session.attributes)) {
-      returnResult.sessionAttributes = this.session.attributes;
-    } else {
-      returnResult.sessionAttributes = {};
+    if (!this.alexaEvent.request.isCanFulfillIntentRequest) {
+      if (this.session && !_.isEmpty(this.session.attributes)) {
+        returnResult.sessionAttributes = this.session.attributes;
+      } else {
+        returnResult.sessionAttributes = {};
+      }
     }
 
     return returnResult;

--- a/lib/Reply.js
+++ b/lib/Reply.js
@@ -115,11 +115,36 @@ class Reply {
       alexaResponse.shouldEndSession = !!this.msg.terminate;
     }
 
+    if (this.canFulfillIntent) {
+      if (!_.includes(['YES', 'NO', 'MAYBE'], this.canFulfillIntent.canFulfill)) {
+        this.canFulfillIntent.canFulfill = 'NO';
+      }
+
+      this.canFulfillIntent.slots = this.canFulfillIntent.slots || {};
+
+      _.each(this.canFulfillIntent.slots, (item) => {
+        if (!_.includes(['YES', 'NO', 'MAYBE'], item.canUnderstand)) {
+          item.canUnderstand = 'NO';
+        }
+
+        if (!_.includes(['YES', 'NO'], item.canFulfill)) {
+          item.canFulfill = 'NO';
+        }
+      });
+
+      alexaResponse.canFulfillIntent = this.canFulfillIntent;
+    } else if (this.alexaEvent.request.isCanFulfillIntentRequest) {
+      alexaResponse.canFulfillIntent = {
+        canFulfill: 'NO',
+      };
+    }
+
     if (reprompt) {
       alexaResponse.reprompt = {
         outputSpeech: Reply.createSpeechObject(reprompt),
       };
     }
+
     if (directives && directives.length > 0) alexaResponse.directives = directives;
 
     const returnResult = {

--- a/lib/Reply.js
+++ b/lib/Reply.js
@@ -124,7 +124,7 @@ class Reply {
       alexaResponse = {
         canFulfillIntent: this.canFulfillIntent,
       };
-    } else if (this.alexaEvent.request.isCanFulfillIntentRequest) {
+    } else if (this.alexaEvent.request.type === 'CanFulfillIntentRequest') {
       alexaResponse = {
         canFulfillIntent: { canFulfill: 'NO' },
       };
@@ -156,7 +156,7 @@ class Reply {
       response: alexaResponse,
     };
 
-    if (!this.alexaEvent.request.isCanFulfillIntentRequest) {
+    if (this.alexaEvent.request.type !== 'CanFulfillIntentRequest') {
       if (this.session && !_.isEmpty(this.session.attributes)) {
         returnResult.sessionAttributes = this.session.attributes;
       } else {

--- a/lib/Reply.js
+++ b/lib/Reply.js
@@ -167,6 +167,17 @@ class Reply {
     return returnResult;
   }
 
+  fulfillIntent(canFulfill) {
+    this.canFulfillIntent = { canFulfill };
+  }
+
+  fulfillSlot(slotName, canUnderstand, canFulfill) {
+    this.canFulfillIntent = this.canFulfillIntent || {};
+    this.canFulfillIntent.slots = this.canFulfillIntent.slots || {};
+
+    this.canFulfillIntent.slots[slotName] = { canUnderstand, canFulfill };
+  }
+
   static toSSML(statement) {
     if (!statement) return undefined;
     if (statement.lastIndexOf('<speak>', 0) >= 0) return statement; // lastIndexOf is a pre Node v6 idiom for startsWith

--- a/lib/StateMachine.js
+++ b/lib/StateMachine.js
@@ -96,9 +96,11 @@ class StateMachine {
             to = { name: 'die' };
           }
 
-
-          if (reply.isYielding() || !transition.to || transition.to.isTerminal) {
+          if (reply.isYielding() || transition.canFulfillIntent ||
+            !transition.to || transition.to.isTerminal) {
             const result = { to };
+            reply.canFulfillIntent = transition.canFulfillIntent || reply.canFulfillIntent;
+
             if (_.isString(transition.reply) || _.isArray(transition.reply)) {
               result.reply = transition.reply;
             }

--- a/lib/StateMachine.js
+++ b/lib/StateMachine.js
@@ -96,10 +96,8 @@ class StateMachine {
             to = { name: 'die' };
           }
 
-          if (reply.isYielding() || transition.canFulfillIntent ||
-            !transition.to || transition.to.isTerminal) {
+          if (reply.isYielding() || !transition.to || transition.to.isTerminal) {
             const result = { to };
-            reply.canFulfillIntent = transition.canFulfillIntent || reply.canFulfillIntent;
 
             if (_.isString(transition.reply) || _.isArray(transition.reply)) {
               result.reply = transition.reply;

--- a/lib/StateMachineSkill.js
+++ b/lib/StateMachineSkill.js
@@ -164,7 +164,7 @@ class StateMachineSkill extends AlexaSkill {
     return stateMachine.transition(alexaEvent, reply)
       .then((transition) => {
         let promise = Promise.resolve(null);
-        if (transition.to.isTerminal) {
+        if (transition.to.isTerminal && !alexaEvent.request.isCanFulfillIntentRequest) {
           promise = this.handleOnSessionEnded(alexaEvent, reply);
         }
 
@@ -176,7 +176,20 @@ class StateMachineSkill extends AlexaSkill {
             return Promise
             .mapSeries(onBeforeReplyHandlers, fn => fn(alexaEvent, reply, transition));
           })
-        .then(() => reply);
+        .then(() => {
+          if (alexaEvent.request.isCanFulfillIntentRequest && _.includes(['YES', 'MAYBE'], _.get(reply, 'canFulfillIntent.canFulfill'))) {
+            alexaEvent.request.isCanFulfillIntentRequest = undefined;
+            debug('canFulfillIntentRequest', JSON.stringify(reply.canFulfillIntent));
+
+            reply.msg.terminate = false;
+
+            return Promise.mapSeries(this.getOnSessionStartedHandlers(),
+              fn => fn(alexaEvent, reply))
+            .then(() => this.requestHandlers.IntentRequest(alexaEvent, reply));
+          }
+
+          return reply;
+        });
       })
     .catch(error => this.handleStateMachineErrors(alexaEvent, reply, error));
   }

--- a/lib/StateMachineSkill.js
+++ b/lib/StateMachineSkill.js
@@ -181,24 +181,15 @@ class StateMachineSkill extends AlexaSkill {
 
         return promise
           .then(() => {
+            if (alexaEvent.request.isCanFulfillIntentRequest) {
+              debug('canFulfillIntentRequest', JSON.stringify(reply.canFulfillIntent));
+            }
+
             debug('Running onBeforeReplySent');
             return Promise
             .mapSeries(onBeforeReplyHandlers, fn => fn(alexaEvent, reply, transition));
           })
-        .then(() => {
-          if (alexaEvent.request.isCanFulfillIntentRequest && _.includes(['YES', 'MAYBE'], _.get(reply, 'canFulfillIntent.canFulfill'))) {
-            alexaEvent.request.isCanFulfillIntentRequest = undefined;
-            debug('canFulfillIntentRequest', JSON.stringify(reply.canFulfillIntent));
-
-            reply.msg.terminate = false;
-
-            return Promise.mapSeries(this.getOnSessionStartedHandlers(),
-              fn => fn(alexaEvent, reply))
-            .then(() => this.requestHandlers.IntentRequest(alexaEvent, reply));
-          }
-
-          return reply;
-        });
+        .then(() => reply);
       })
     .catch(error => this.handleStateMachineErrors(alexaEvent, reply, error));
   }

--- a/lib/StateMachineSkill.js
+++ b/lib/StateMachineSkill.js
@@ -58,6 +58,15 @@ class StateMachineSkill extends AlexaSkill {
       }, true);
     });
 
+    // we treat onDisplay.ElementSelected as an intentRequest
+    this['onDisplay.ElementSelected']((alexaEvent, reply) => {
+      const intent = 'DisplayElementSelected';
+      _.set(alexaEvent, 'intent.name', intent);
+      _.set(alexaEvent, 'intent.slots', {});
+
+      return this.requestHandlers.IntentRequest(alexaEvent, reply);
+    }, true);
+
     // run the state machine for intentRequests
     this.onIntentRequest(this.runStateMachine, true);
     // my default is to render with the message renderer on state machine

--- a/lib/StateMachineSkill.js
+++ b/lib/StateMachineSkill.js
@@ -58,15 +58,6 @@ class StateMachineSkill extends AlexaSkill {
       }, true);
     });
 
-    // we treat onDisplay.ElementSelected as an intentRequest
-    this['onDisplay.ElementSelected']((alexaEvent, reply) => {
-      const intent = 'DisplayElementSelected';
-      _.set(alexaEvent, 'intent.name', intent);
-      _.set(alexaEvent, 'intent.slots', {});
-
-      return this.requestHandlers.IntentRequest(alexaEvent, reply);
-    }, true);
-
     // run the state machine for intentRequests
     this.onIntentRequest(this.runStateMachine, true);
     // my default is to render with the message renderer on state machine
@@ -173,7 +164,7 @@ class StateMachineSkill extends AlexaSkill {
     return stateMachine.transition(alexaEvent, reply)
       .then((transition) => {
         let promise = Promise.resolve(null);
-        if (transition.to.isTerminal && !alexaEvent.request.isCanFulfillIntentRequest) {
+        if (transition.to.isTerminal) {
           promise = this.handleOnSessionEnded(alexaEvent, reply);
         }
 
@@ -181,10 +172,6 @@ class StateMachineSkill extends AlexaSkill {
 
         return promise
           .then(() => {
-            if (alexaEvent.request.isCanFulfillIntentRequest) {
-              debug('canFulfillIntentRequest', JSON.stringify(reply.canFulfillIntent));
-            }
-
             debug('Running onBeforeReplySent');
             return Promise
             .mapSeries(onBeforeReplyHandlers, fn => fn(alexaEvent, reply, transition));

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "istanbul cover _mocha -- --recursive test",
     "test-ci": "JUNIT_REPORT_PATH=junit.xml istanbul cover _mocha -- --recursive --colors --reporter mocha-jenkins-reporter test",
     "cobertura": "istanbul report cobertura --root coverage",
-    "lint": "eslint lib test"
+    "lint": "eslint lib test",
+    "lint-fix": "eslint --fix lib test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voxa",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A fsm (state machine) framework for Alexa apps using Node.js",
   "main": "index.js",
   "scripts": {

--- a/samples/accountLinking/config/local.json
+++ b/samples/accountLinking/config/local.json
@@ -1,0 +1,26 @@
+{
+  "server": {
+    "port": 3000,
+    "hostSkill": true
+  },
+  "alexa": {
+    "auth": {
+      "redirectUrl": "",
+      "clientId": "",
+      "clientSecret": "",
+      "codeKey": "",
+      "token_expiration": 1576800000
+    }
+  },
+  "s3": {
+    "bucket": ""
+  },
+  "dynamoDB": {
+    "tables": {
+      "users": "accountLinkingExample"
+    }
+  },
+  "aws": {
+    "region": "us-east-1"
+  }
+}

--- a/samples/accountLinking/skill/states.js
+++ b/samples/accountLinking/skill/states.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const _ = require('lodash');
+
+exports.register = function register(skill) {
+  skill.onIntent('LaunchIntent', (alexaEvent) => {
+    if (_.get(alexaEvent, 'model.user.email')) {
+      return { reply: 'Intent.Launch', to: 'entry' };
+    }
+
+    return { reply: 'Intent.NotAuthenticated', to: 'die' };
+  });
+
+  skill.onIntent('AMAZON.HelpIntent', () => ({ reply: 'Intent.Help' }));
+
+  skill['onAlexaSkillEvent.SkillEnabled']((alexaEvent, reply) => {
+    const userId = alexaEvent.user.userId;
+    const timestamp = alexaEvent.request.timestamp;
+    console.log(`skill was enabled for user: ${userId} at ${timestamp}`);
+    return reply;
+  });
+
+  skill['onAlexaSkillEvent.SkillAccountLinked']((alexaEvent, reply) => {
+    const userId = alexaEvent.user.userId;
+    const accessToken = alexaEvent.request.body.accessToken;
+    console.log(`User: ${userId} linked his account. Access Token is ${accessToken}`);
+    return reply;
+  });
+};

--- a/samples/starterKit/config/local.json
+++ b/samples/starterKit/config/local.json
@@ -1,0 +1,6 @@
+{
+  "server": {
+    "port": 3000,
+    "hostSkill": true
+  }
+}

--- a/test/AlexaSkill.spec.js
+++ b/test/AlexaSkill.spec.js
@@ -11,6 +11,15 @@ const simple = require('simple-mock');
 const _ = require('lodash');
 
 describe('AlexaSkill', () => {
+  it('should add the context to the alexaEvent object', () => {
+    const ctx = { value: 'context' };
+    const alexaSkill = new AlexaSkill();
+    return alexaSkill.execute({ context: { application: { applicationId: 'MY APP ID' } }, request: { intent: { } } }, ctx)
+    .then((reply) => {
+      expect(reply.alexaEvent.lambdaContext).to.deep.equal(ctx);
+    });
+  });
+
   it('should return error message on wrong appId Array if config.appIds is defined', () => {
     const alexaSkill = new AlexaSkill({ appIds: ['MY APP ID'] });
     alexaSkill.onLaunchRequest(() => {});

--- a/test/Reply.spec.js
+++ b/test/Reply.spec.js
@@ -147,6 +147,38 @@ describe('Reply', () => {
         version: '1.0',
       });
     });
+
+    it('should generate a correct alexa response for a CanFulfillIntentRequest', () => {
+      const replyCanFulfill = _.cloneDeep(reply);
+      replyCanFulfill.canFulfillIntent = {
+        canFulfill: 'YES',
+        slots: {
+          slot1: {
+            canUnderstand: 'YES',
+            canFulfill: 'YES',
+          },
+        },
+      };
+
+      expect(replyCanFulfill.toJSON()).to.deep.equal({
+        response: {
+          card: undefined,
+          outputSpeech: undefined,
+          shouldEndSession: true,
+          canFulfillIntent: {
+            canFulfill: 'YES',
+            slots: {
+              slot1: {
+                canUnderstand: 'YES',
+                canFulfill: 'YES',
+              },
+            },
+          },
+        },
+        sessionAttributes: {},
+        version: '1.0',
+      });
+    });
   });
 
   describe('append', () => {

--- a/test/Reply.spec.js
+++ b/test/Reply.spec.js
@@ -162,9 +162,6 @@ describe('Reply', () => {
 
       expect(replyCanFulfill.toJSON()).to.deep.equal({
         response: {
-          card: undefined,
-          outputSpeech: undefined,
-          shouldEndSession: true,
           canFulfillIntent: {
             canFulfill: 'YES',
             slots: {

--- a/test/StateMachineSkill.spec.js
+++ b/test/StateMachineSkill.spec.js
@@ -358,7 +358,7 @@ describe('StateMachineSkill', () => {
     return stateMachineSkill.execute(fulfillEvent)
       .then((reply) => {
         expect(reply.canFulfillIntent).to.deep.equal(canFulfillIntent);
-        expect(reply.msg.statements[0]).to.deep.equal('This is my message');
+        expect(reply.msg.statements[0]).to.be.undefined;
         expect(reply.toJSON().response.canFulfillIntent).to.deep.equal(canFulfillIntent);
       });
   });
@@ -398,7 +398,7 @@ describe('StateMachineSkill', () => {
     return stateMachineSkill.execute(fulfillEvent)
       .then((reply) => {
         expect(reply.canFulfillIntent).to.deep.equal(canFulfillIntent);
-        expect(reply.msg.statements[0]).to.deep.equal('This is my message');
+        expect(reply.msg.statements[0]).to.be.undefined;
         expect(reply.toJSON().response.canFulfillIntent).to.deep.equal(canFulfillIntent);
       });
   });

--- a/test/StateMachineSkill.spec.js
+++ b/test/StateMachineSkill.spec.js
@@ -335,13 +335,44 @@ describe('StateMachineSkill', () => {
     };
 
     const stateMachineSkill = new StateMachineSkill({ variables, views });
-    stateMachineSkill.onIntent('NameIntent', (alexaEvent) => {
-      if (alexaEvent.request.isCanFulfillIntentRequest) {
-        return { canFulfillIntent };
-      }
-
-      return { message: { ask: 'This is my message' } };
+    stateMachineSkill.onCanFulfillIntentRequest((alexaEvent, reply) => {
+      reply.canFulfillIntent = canFulfillIntent;
+      return reply;
     });
+
+    const fulfillEvent = _.cloneDeep(event);
+    fulfillEvent.request.type = 'CanFulfillIntentRequest';
+    fulfillEvent.request.intent = {
+      name: 'NameIntent',
+      slots: {
+        slot1: {
+          name: 'slot1',
+          value: 'something',
+        },
+      },
+    };
+
+    return stateMachineSkill.execute(fulfillEvent)
+      .then((reply) => {
+        expect(reply.canFulfillIntent).to.deep.equal(canFulfillIntent);
+        expect(reply.msg.statements[0]).to.be.undefined;
+        expect(reply.toJSON().response.canFulfillIntent).to.deep.equal(canFulfillIntent);
+      });
+  });
+
+  it('should fulfill request with default intents', () => {
+    const canFulfillIntent = {
+      canFulfill: 'YES',
+      slots: {
+        slot1: {
+          canUnderstand: 'YES',
+          canFulfill: 'YES',
+        },
+      },
+    };
+
+    const defaultFulfillIntents = ['NameIntent'];
+    const stateMachineSkill = new StateMachineSkill({ variables, views, defaultFulfillIntents });
 
     const fulfillEvent = _.cloneDeep(event);
     fulfillEvent.request.type = 'CanFulfillIntentRequest';
@@ -375,12 +406,9 @@ describe('StateMachineSkill', () => {
     };
 
     const stateMachineSkill = new StateMachineSkill({ variables, views });
-    stateMachineSkill.onIntent('NameIntent', (alexaEvent) => {
-      if (alexaEvent.request.isCanFulfillIntentRequest) {
-        return { canFulfillIntent };
-      }
-
-      return { message: { ask: 'This is my message' } };
+    stateMachineSkill.onCanFulfillIntentRequest((alexaEvent, reply) => {
+      reply.canFulfillIntent = canFulfillIntent;
+      return reply;
     });
 
     const fulfillEvent = _.cloneDeep(event);
@@ -409,7 +437,10 @@ describe('StateMachineSkill', () => {
     };
 
     const stateMachineSkill = new StateMachineSkill({ variables, views });
-    stateMachineSkill.onIntent('NameIntent', () => ({ canFulfillIntent }));
+    stateMachineSkill.onCanFulfillIntentRequest((alexaEvent, reply) => {
+      reply.canFulfillIntent = canFulfillIntent;
+      return reply;
+    });
 
     const fulfillEvent = _.cloneDeep(event);
     fulfillEvent.request.type = 'CanFulfillIntentRequest';
@@ -452,7 +483,10 @@ describe('StateMachineSkill', () => {
     };
 
     const stateMachineSkill = new StateMachineSkill({ variables, views });
-    stateMachineSkill.onIntent('NameIntent', () => ({ canFulfillIntent }));
+    stateMachineSkill.onCanFulfillIntentRequest((alexaEvent, reply) => {
+      reply.canFulfillIntent = canFulfillIntent;
+      return reply;
+    });
 
     const fulfillEvent = _.cloneDeep(event);
     fulfillEvent.request.type = 'CanFulfillIntentRequest';
@@ -489,7 +523,10 @@ describe('StateMachineSkill', () => {
     };
 
     const stateMachineSkill = new StateMachineSkill({ variables, views });
-    stateMachineSkill.onIntent('NameIntent', () => ({ canFullfillIntent: canFulfillIntent }));
+    stateMachineSkill.onCanFulfillIntentRequest((alexaEvent, reply) => {
+      reply.canFullfillIntent = canFulfillIntent;
+      return reply;
+    });
 
     const fulfillEvent = _.cloneDeep(event);
     fulfillEvent.request.type = 'CanFulfillIntentRequest';


### PR DESCRIPTION
For more information about `CanFulfillIntentRequest`, visit these 2 links:

https://developer.amazon.com/docs/custom-skills/understand-name-free-interaction-for-custom-skills.html
https://developer.amazon.com/docs/custom-skills/quick-start-canfulfill-intent-request.html

The way it's meant to work is that in every intent should validate the scenario when this value is coming:

```
skill.onIntent('MyIntent', (alexaEvent) => {
    if (alexaEvent.request.isCanFulfillIntentRequest) {
        const canFulfillIntent = { canFulfill: 'YES' };
        return { canFulfillIntent };
    }

    // DO YOUR NORMAL CODE
});
```