### PR TITLE
Voxa SSML appending works with SSML that contains new lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ Resources
 * [Documentation](http://voxa.readthedocs.io/en/latest/)
 * [Bug Tracker](https://github.com/mediarain/voxa/issues)
 * [Mail List](https://groups.google.com/d/forum/voxa-framework)
+

--- a/src/StateMachine.ts
+++ b/src/StateMachine.ts
@@ -62,20 +62,20 @@ export function isState(object: any): object is IState {
 class SystemTransition implements ITransition {
 
   [propname: string]: any;
-  to?: string|IState|ITransition; // default to 'entry'
-  flow?: string;
+  public to?: string|IState|ITransition; // default to 'entry'
+  public flow?: string;
 
   constructor(transition: ITransition) {
     Object.assign(this, transition);
     this.flow = this.flow || "continue";
   }
 
-  get shouldTerminate() : boolean {
-    return this.flow === 'terminate' || ( isState(this.to) && this.to.isTerminal);
+  get shouldTerminate(): boolean {
+    return this.flow === "terminate" || ( isState(this.to) && this.to.isTerminal);
   }
 
-  get shouldContinue() : boolean {
-    return this.flow == "continue" && this.to && isState(this.to) && !this.to.isTerminal
+  get shouldContinue(): boolean {
+    return this.flow === "continue" && this.to && isState(this.to) && !this.to.isTerminal;
   }
 }
 
@@ -213,7 +213,7 @@ export class StateMachine {
     transition = await this.checkForEntryFallback(voxaEvent, reply, transition);
     transition = await this.checkOnUnhandledState(voxaEvent, reply, transition);
     transition = await this.onAfterStateChanged(voxaEvent, reply, transition);
-    let sysTransition = new SystemTransition(transition)
+    const sysTransition = new SystemTransition(transition);
     let to;
 
     if (sysTransition.to && _.isString(sysTransition.to)) {

--- a/src/StateMachine.ts
+++ b/src/StateMachine.ts
@@ -38,6 +38,7 @@ export interface IStateMachineConfig {
 export interface ITransition {
   [propname: string]: any;
   to?: string|IState|ITransition; // default to 'entry'
+  flow?: string;
 }
 
 export interface IState {
@@ -53,6 +54,29 @@ export function isTransition(object: any): object is ITransition {
 
 export function isState(object: any): object is IState {
   return object  && "name" in object ;
+}
+
+// A helper class for transitions. Users can return transitions as an object with various command keys.
+// For developer flexibility we allow that transition object to be vague.
+// This object wraps the ITransition and gives defaults helps interpret what the various toggles mean.
+class SystemTransition implements ITransition {
+
+  [propname: string]: any;
+  to?: string|IState|ITransition; // default to 'entry'
+  flow?: string;
+
+  constructor(transition: ITransition) {
+    Object.assign(this, transition);
+    this.flow = this.flow || "continue";
+  }
+
+  get shouldTerminate() : boolean {
+    return this.flow === 'terminate' || ( isState(this.to) && this.to.isTerminal);
+  }
+
+  get shouldContinue() : boolean {
+    return this.flow == "continue" && this.to && isState(this.to) && !this.to.isTerminal
+  }
 }
 
 export class StateMachine {
@@ -189,39 +213,28 @@ export class StateMachine {
     transition = await this.checkForEntryFallback(voxaEvent, reply, transition);
     transition = await this.checkOnUnhandledState(voxaEvent, reply, transition);
     transition = await this.onAfterStateChanged(voxaEvent, reply, transition);
+    let sysTransition = new SystemTransition(transition)
     let to;
 
-    if (_.isObject(transition) && !_.isEmpty(transition) && !transition.flow) {
-      transition = _.merge({}, transition, {flow: "continue"});
-      transition.flow = "continue";
-    }
-
-    if (transition.to && _.isString(transition.to)) {
-      if (!this.states.core[transition.to] && !_.get(this.states, [voxaEvent.platform, transition.to])) {
-        throw new UnknownState(transition.to);
+    if (sysTransition.to && _.isString(sysTransition.to)) {
+      if (!this.states.core[sysTransition.to] && !_.get(this.states, [voxaEvent.platform, sysTransition.to])) {
+        throw new UnknownState(sysTransition.to);
       }
-      to = _.get(this.states, [voxaEvent.platform, transition.to]) || this.states.core[transition.to];
-      transition = _.merge({}, transition, { to });
+      to = _.get(this.states, [voxaEvent.platform, sysTransition.to]) || this.states.core[sysTransition.to];
+      Object.assign(sysTransition, {to});
     } else {
       to = { name: "die" };
-      transition = _.merge({}, transition, { flow: "terminate" });
+      sysTransition.flow = "terminate";
     }
 
-    if (transition.flow === "terminate" ) {
+    if (sysTransition.shouldTerminate) {
       reply.terminate();
     }
 
-    if (isState(transition.to)) {
-      if (transition.to.isTerminal) {
-        reply.terminate();
-      }
+    if (sysTransition.shouldContinue) {
+      return this.runTransition(to.name, voxaEvent, reply);
     }
-
-    if (transition.flow !== "continue" || !transition.to || isState(transition.to) && transition.to.isTerminal) {
-      return _.merge({}, transition, to);
-    }
-
-    return this.runTransition(to.name, voxaEvent, reply);
+    return _.merge({}, sysTransition, to);
   }
 
   public async runCurrentState(voxaEvent: IVoxaEvent, reply: IVoxaReply): Promise<ITransition> {

--- a/src/StateMachine.ts
+++ b/src/StateMachine.ts
@@ -75,7 +75,7 @@ class SystemTransition implements ITransition {
   }
 
   get shouldContinue(): boolean {
-    return this.flow === "continue" && this.to && isState(this.to) && !this.to.isTerminal;
+    return !!(this.flow === "continue" && this.to && isState(this.to) && !this.to.isTerminal);
   }
 }
 

--- a/src/VoxaReply.ts
+++ b/src/VoxaReply.ts
@@ -55,7 +55,7 @@ export interface IVoxaReply {
 }
 
 export function addToSSML(ssml: string, statement: string): string {
-  const base = ssml.replace(/^<speak>(.*)<\/speak>$/g,  "$1");
+  const base = ssml.replace(/^<speak>([\s\S]*)<\/speak>$/g,  "$1");
   if (!base) {
     return `<speak>${statement}</speak>`;
   }

--- a/test/VoxaReply.spec.ts
+++ b/test/VoxaReply.spec.ts
@@ -18,7 +18,8 @@ describe("VoxaReply", () => {
       expect(addToSSML("<speak>Howdy</speak>", "there")).to.equal("<speak>Howdy\nthere</speak>");
     });
     it("handles SSML that contains newlines", () => {
-      expect(addToSSML("<speak>Howdy\n and a good day to you</speak>", "there")).to.equal("<speak>Howdy\n and a good day to you\nthere</speak>");
+      expect(addToSSML("<speak>Howdy\n and a good day to you</speak>", "there"))
+        .to.equal("<speak>Howdy\n and a good day to you\nthere</speak>");
     });
   });
 });

--- a/test/VoxaReply.spec.ts
+++ b/test/VoxaReply.spec.ts
@@ -13,4 +13,12 @@ describe("VoxaReply", () => {
       expect(addToText("text", "statement")).to.equal("text statement");
     });
   });
+  describe("addToSSML", () => {
+    it("should append a statement to ssml by inserting a newline between", () => {
+      expect(addToSSML("<speak>Howdy</speak>", "there")).to.equal("<speak>Howdy\nthere</speak>");
+    });
+    it("handles SSML that contains newlines", () => {
+      expect(addToSSML("<speak>Howdy\n and a good day to you</speak>", "there")).to.equal("<speak>Howdy\n and a good day to you\nthere</speak>");
+    });
+  });
 });


### PR DESCRIPTION
There was a bug in the SSML append code that would fail to unwrap the `<speak>` tags from SSML that contained newlines. This is a fix.

I also took an opportunity to re-structure some code in the StateMachine to make it a touch more self-documenting.