### PR TITLE
Data access changes

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -3,7 +3,7 @@
 Models
 ======
 
-Models are the data structure that holds the current state of your application, the framework doesn't make many assumptions on it and only requires  have a ``fromEvent`` method that should initialize it based on
-``voxaEvent.session.attributes`` and a ``serialize`` method that should return a ``JSON.stringify`` able structure to then store in the session attributes
+Models are the data structure that holds the current state of your application, the framework doesn't make many assumptions on it and only requires  have a ``deserialize`` method that should initialize it based on
+an object of attributes and a ``serialize`` method that should return a ``JSON.stringify`` able structure to then store in the session attributes.
 
 .. literalinclude:: ../src/Model.ts

--- a/docs/voxa-app.rst
+++ b/docs/voxa-app.rst
@@ -133,12 +133,14 @@ Voxa
 
 .. js:function:: VoxaApp.onRequestStarted(callback, [atLast])
 
-  Adds a callback to be executed whenever there's a ``LaunchRequest``, ``IntentRequest`` or a ``SessionEndedRequest``, this can be used to initialize your analytics or get your account linking user data. Internally it's used to initialize the model based on the event session
+  Adds a callback to be executed whenever there's a ``LaunchRequest``, ``IntentRequest`` or a ``SessionEndedRequest``,
+  this can be used to initialize your analytics or get your account linking user data. Internally it's used to initialize the model based on the event session
 
   .. code-block:: javascript
 
     skill.onRequestStarted((voxaEvent, reply) => {
-      voxaEvent.model = this.config.Model.fromEvent(voxaEvent);
+      let data = ... // deserialized from the platform's session
+      voxaEvent.model = this.config.Model.deserialize(data, voxaEvent);
     });
 
 

--- a/hello-world/hello-world.spec.js
+++ b/hello-world/hello-world.spec.js
@@ -54,7 +54,7 @@ describe("Hello World", () => {
           outputSpeech:
           { ssml: '<speak>Welcome to this voxa app, are you enjoying voxa so far?</speak>',
             type: 'SSML' } },
-        sessionAttributes: { state: 'likesVoxa?' }
+        sessionAttributes: { state: 'likesVoxa?', model: {} }
       });
 
     });
@@ -68,7 +68,7 @@ describe("Hello World", () => {
       });
 
       expect(lambdaCallbackResult).to.deep.equal( {
-        "body": "{\"outputContexts\":[{\"name\":\"projects/project/agent/sessions/1525973454075/contexts/model\",\"lifespanCount\":10000,\"parameters\":{\"model\":\"{\\\"state\\\":\\\"likesVoxa?\\\"}\"}}],\"fulfillmentText\":\"<speak>Welcome to this voxa app, are you enjoying voxa so far?</speak>\",\"source\":\"google\",\"payload\":{\"google\":{\"expectUserResponse\":true,\"isSsml\":true,\"richResponse\":{\"items\":[{\"simpleResponse\":{\"textToSpeech\":\"<speak>Welcome to this voxa app, are you enjoying voxa so far?</speak>\"}}]}}}}",
+        "body": "{\"outputContexts\":[{\"name\":\"projects/project/agent/sessions/1525973454075/contexts/attributes\",\"lifespanCount\":10000,\"parameters\":{\"attributes\":\"{\\\"model\\\":{},\\\"state\\\":\\\"likesVoxa?\\\"}\"}}],\"fulfillmentText\":\"<speak>Welcome to this voxa app, are you enjoying voxa so far?</speak>\",\"source\":\"google\",\"payload\":{\"google\":{\"expectUserResponse\":true,\"isSsml\":true,\"richResponse\":{\"items\":[{\"simpleResponse\":{\"textToSpeech\":\"<speak>Welcome to this voxa app, are you enjoying voxa so far?</speak>\"}}]}}}}",
         "headers": {
           "Content-Type": "application/json",
         },

--- a/hello-world/yarn.lock
+++ b/hello-world/yarn.lock
@@ -172,7 +172,7 @@ asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
-ask-sdk-core@^2.0.3, ask-sdk-core@^2.0.7:
+ask-sdk-core@^2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/ask-sdk-core/-/ask-sdk-core-2.0.7.tgz#0f2300aa99a5bd92c0bd700d1ed92ff8da1f83b9"
 
@@ -182,11 +182,15 @@ ask-sdk-dynamodb-persistence-adapter@^2.0.7:
   dependencies:
     aws-sdk "^2.163.0"
 
-ask-sdk-model@^1.0.0, ask-sdk-model@^1.2.0:
+ask-sdk-model@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ask-sdk-model/-/ask-sdk-model-1.3.1.tgz#a583809e4e9d3fb5308306249907808fab37fd4f"
 
-ask-sdk@^2.0.3:
+ask-sdk-model@^1.4.0-beta.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/ask-sdk-model/-/ask-sdk-model-1.4.1.tgz#cbc3e071ac720336ee289dd0a57e6bbdf5c9d0f9"
+
+ask-sdk@^2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/ask-sdk/-/ask-sdk-2.0.7.tgz#1157fb90399b50bb1deab55a866255fba4317d72"
   dependencies:
@@ -978,9 +982,9 @@ verror@1.10.0:
     "@types/url-join" "^0.8.2"
     "@types/uuid" "^3.4.3"
     actions-on-google "2"
-    ask-sdk "^2.0.3"
-    ask-sdk-core "^2.0.3"
-    ask-sdk-model "^1.2.0"
+    ask-sdk "^2.0.7"
+    ask-sdk-core "^2.0.7"
+    ask-sdk-model "^1.4.0-beta.1"
     azure-functions-ts-essentials "^1.3.2"
     bluebird "^3.5.1"
     botbuilder "^3.13.1"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "prepare": "npm run clean && tsc",
     "compile": "tsc",
     "lint": "tslint --project tsconfig.json --config tslint.json ",
+    "lint-fix": "tslint --project tsconfig.json --config tslint.json --fix ",
     "report": "nyc report --reporter=json && nyc report --reporter html && nyc report --reporter=lcov && nyc report --reporter=cobertura",
     "test": "mocha test/*.spec.* test/**/*.spec.*",
     "test-ci": "nyc mocha --colors --reporter mocha-jenkins-reporter test test/*.spec.* test/**/*.spec.*"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "prepare": "npm run clean && tsc",
     "compile": "tsc",
     "lint": "tslint --project tsconfig.json --config tslint.json ",
-    "lint-fix": "tslint --project tsconfig.json --config tslint.json --fix ",
     "report": "nyc report --reporter=json && nyc report --reporter html && nyc report --reporter=lcov && nyc report --reporter=cobertura",
     "test": "mocha test/*.spec.* test/**/*.spec.*",
     "test-ci": "nyc mocha --colors --reporter mocha-jenkins-reporter test test/*.spec.* test/**/*.spec.*"

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -4,8 +4,8 @@ import { IVoxaEvent } from "./VoxaEvent";
 export class Model {
   [key: string]: any
 
-  public static fromEvent(voxaEvent: IVoxaEvent): Promise<Model>|Model {
-    return new this(voxaEvent.session.attributes);
+  public static deserialize(data: object, voxaEvent: IVoxaEvent): Promise<Model>|Model {
+    return new this(data);
   }
 
   public state?: string;
@@ -21,5 +21,5 @@ export class Model {
 
 export interface IModel {
   new (data?: any): Model;
-  fromEvent(data?: any): Model|Promise<Model>;
+  deserialize(data: object, event: IVoxaEvent): Model|Promise<Model>;
 }

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -1,10 +1,10 @@
 import * as _ from "lodash";
-import { IVoxaEvent } from "./VoxaEvent";
+import { IBag, IVoxaEvent } from "./VoxaEvent";
 
 export class Model {
   [key: string]: any
 
-  public static deserialize(data: object, voxaEvent: IVoxaEvent): Promise<Model>|Model {
+  public static deserialize(data: IBag, voxaEvent: IVoxaEvent): Promise<Model>|Model {
     return new this(data);
   }
 
@@ -21,5 +21,5 @@ export class Model {
 
 export interface IModel {
   new (data?: any): Model;
-  deserialize(data: object, event: IVoxaEvent): Model|Promise<Model>;
+  deserialize(data: IBag, event: IVoxaEvent): Model|Promise<Model>;
 }

--- a/src/VoxaEvent.ts
+++ b/src/VoxaEvent.ts
@@ -72,8 +72,19 @@ export interface IVoxaIntent {
   params: any;
 }
 
+export interface IBag extends Object {
+  [key: string]: any;
+}
+
 export interface IVoxaSession {
-  attributes: any;
+  // Session attributes that are attributes that are  inbound on the event.
+  // These have been set by in the prior event by setting the outputAttributes.
+  attributes: IBag;
+
+  // Attributes that will be carried forward into the next event.
+  outputAttributes: IBag;
+
+  // True if this request is the first in the session.
   new: boolean;
   sessionId: string;
 }

--- a/src/VoxaReply.ts
+++ b/src/VoxaReply.ts
@@ -12,7 +12,7 @@ import * as bluebird from "bluebird";
 import * as debug from "debug";
 
 import { IMessage } from "./renderers/Renderer";
-import { IVoxaEvent } from "./VoxaEvent";
+import { IBag, IVoxaEvent } from "./VoxaEvent";
 
 const log: debug.IDebugger = debug("voxa");
 
@@ -55,7 +55,7 @@ export interface IVoxaReply {
   // Attributes stored to the session should be made available in the platform's subsequent event
   // under `event.session.attributes`. In this way, devs can use the session carry data forward
   // through the conversation.
-  saveSession: (attributes: object, event: IVoxaEvent) => void;
+  saveSession: (attributes: IBag, event: IVoxaEvent) => void;
 }
 
 export function addToSSML(ssml: string, statement: string): string {

--- a/src/VoxaReply.ts
+++ b/src/VoxaReply.ts
@@ -51,7 +51,11 @@ export interface IVoxaReply {
   // }
   //
 
-  saveSession: (event: IVoxaEvent) => void;
+  // saveSession should store the attributes object into a storage that is scoped to the session.
+  // Attributes stored to the session should be made available in the platform's subsequent event
+  // under `event.session.attributes`. In this way, devs can use the session carry data forward
+  // through the conversation.
+  saveSession: (attributes: object, event: IVoxaEvent) => void;
 }
 
 export function addToSSML(ssml: string, statement: string): string {

--- a/src/errors/InvalidTransitionError.ts
+++ b/src/errors/InvalidTransitionError.ts
@@ -1,0 +1,9 @@
+export class InvalidTransitionError extends Error {
+  public transition: any;
+
+  constructor(transition: any, details: string) {
+    const message = `Transition was not valid ${details}. ${transition}`;
+    super(message);
+    this.transition = transition;
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -4,3 +4,4 @@ export { UnknownRequestType } from "./UnknownRequestType";
 export { UnknownState } from "./UnknownState";
 export { NotImplementedError } from "./NotImplementedError";
 export { TimeoutError } from "./TimeoutError";
+export { InvalidTransitionError } from "./InvalidTransitionError";

--- a/src/platforms/alexa/AlexaEvent.ts
+++ b/src/platforms/alexa/AlexaEvent.ts
@@ -32,7 +32,8 @@ export class AlexaEvent extends IVoxaEvent {
 
   constructor(event: RequestEnvelope , context?: any) {
     super(event, context);
-    this.session = _.cloneDeep(event.session) as IVoxaSession;
+    this.session = (_.cloneDeep(event.session) || {}) as IVoxaSession;
+    this.session.outputAttributes = {};
     this.request = _.cloneDeep(event.request);
     this.context = _.cloneDeep(event.context);
     this.executionContext = context;

--- a/src/platforms/alexa/AlexaReply.ts
+++ b/src/platforms/alexa/AlexaReply.ts
@@ -5,13 +5,13 @@ import {
 } from "ask-sdk-model";
 import * as _ from "lodash";
 import { Model } from "../../Model";
-import { IVoxaEvent } from "../../VoxaEvent";
+import { IBag, IVoxaEvent } from "../../VoxaEvent";
 import { addToSSML, addToText, IVoxaReply } from "../../VoxaReply";
 
 export class AlexaReply implements IVoxaReply, ResponseEnvelope {
   public version = "1.0";
   public response: Response = {};
-  public sessionAttributes: any;
+  public sessionAttributes: IBag = {};
 
   get hasMessages() {
     return !!this.response.outputSpeech;
@@ -33,8 +33,8 @@ export class AlexaReply implements IVoxaReply, ResponseEnvelope {
     return !!this.response && !!this.response.shouldEndSession;
   }
 
-  public async saveSession(event: IVoxaEvent): Promise<void> {
-    this.sessionAttributes = await event.model.serialize();
+  public async saveSession(attributes: object , event: IVoxaEvent): Promise<void> {
+    this.sessionAttributes = attributes;
   }
 
   public terminate() {

--- a/src/platforms/alexa/AlexaReply.ts
+++ b/src/platforms/alexa/AlexaReply.ts
@@ -33,7 +33,7 @@ export class AlexaReply implements IVoxaReply, ResponseEnvelope {
     return !!this.response && !!this.response.shouldEndSession;
   }
 
-  public async saveSession(attributes: object , event: IVoxaEvent): Promise<void> {
+  public async saveSession(attributes: IBag , event: IVoxaEvent): Promise<void> {
     this.sessionAttributes = attributes;
   }
 

--- a/src/platforms/botframework/BotFrameworkEvent.ts
+++ b/src/platforms/botframework/BotFrameworkEvent.ts
@@ -55,6 +55,7 @@ export class BotFrameworkEvent extends IVoxaEvent {
     this.session = {
       attributes: stateData.privateConversationData || {},
       new: _.isEmpty(stateData.privateConversationData),
+      outputAttributes: {},
       sessionId: _.get(message, "address.conversation.id"),
     };
 

--- a/src/platforms/botframework/BotFrameworkReply.ts
+++ b/src/platforms/botframework/BotFrameworkReply.ts
@@ -205,7 +205,7 @@ export class BotFrameworkReply implements IVoxaReply {
     return await rp(requestOptions) as IAuthorizationResponse;
   }
 
-  public async saveSession(event: IVoxaEvent): Promise<void> {
+  public async saveSession(attributes: object, event: IVoxaEvent): Promise<void> {
     const conversationId = event.session.sessionId;
     const userId = event.rawEvent.address.bot.id;
     const context: IBotStorageContext = {
@@ -217,16 +217,12 @@ export class BotFrameworkReply implements IVoxaReply {
 
     const storage = (event as BotFrameworkEvent).storage;
 
-    if (!event.model) {
-      return;
-    }
-
     const data: IBotStorageData = {
       conversationData: {},
       // we're only gonna handle private conversation data, this keeps the code small
       // and more importantly it makes it so the programming model is the same between
       // the different platforms
-      privateConversationData: await event.model.serialize(),
+      privateConversationData: attributes,
       userData: {},
     };
 

--- a/src/platforms/botframework/BotFrameworkReply.ts
+++ b/src/platforms/botframework/BotFrameworkReply.ts
@@ -15,7 +15,7 @@ import { StatusCodeError } from "request-promise/errors";
 import * as urljoin from "url-join";
 import * as uuid from "uuid";
 import { NotImplementedError } from "../../errors";
-import { IVoxaEvent } from "../../VoxaEvent";
+import { IBag, IVoxaEvent } from "../../VoxaEvent";
 import { addToSSML, addToText, IVoxaReply } from "../../VoxaReply";
 import { BotFrameworkEvent } from "./BotFrameworkEvent";
 import { IAuthorizationResponse } from "./BotFrameworkInterfaces";
@@ -205,7 +205,7 @@ export class BotFrameworkReply implements IVoxaReply {
     return await rp(requestOptions) as IAuthorizationResponse;
   }
 
-  public async saveSession(attributes: object, event: IVoxaEvent): Promise<void> {
+  public async saveSession(attributes: IBag, event: IVoxaEvent): Promise<void> {
     const conversationId = event.session.sessionId;
     const userId = event.rawEvent.address.bot.id;
     const context: IBotStorageContext = {

--- a/src/platforms/dialog-flow/DialogFlowReply.ts
+++ b/src/platforms/dialog-flow/DialogFlowReply.ts
@@ -38,10 +38,10 @@ export class DialogFlowReply implements IVoxaReply {
     };
   }
 
-  public async saveSession(event: IVoxaEvent): Promise<void> {
+  public async saveSession(attributes: object, event: IVoxaEvent): Promise<void> {
     const dialogFlowEvent = event as DialogFlowEvent;
-    const serializedData = JSON.stringify(await event.model.serialize());
-    dialogFlowEvent.conv.contexts.set("model", 10000, { model: serializedData });
+    const serializedData = JSON.stringify(attributes);
+    dialogFlowEvent.conv.contexts.set("attributes", 10000, { attributes: serializedData });
 
     this.outputContexts = dialogFlowEvent.conv.contexts._serialize();
   }

--- a/src/platforms/dialog-flow/DialogFlowReply.ts
+++ b/src/platforms/dialog-flow/DialogFlowReply.ts
@@ -6,7 +6,7 @@ import {
 } from "actions-on-google";
 import * as _ from "lodash";
 import { Model } from "../../Model";
-import { IVoxaEvent } from "../../VoxaEvent";
+import { IBag, IVoxaEvent } from "../../VoxaEvent";
 import { addToSSML, addToText, IVoxaReply } from "../../VoxaReply";
 import { DialogFlowEvent } from "./DialogFlowEvent";
 
@@ -38,7 +38,7 @@ export class DialogFlowReply implements IVoxaReply {
     };
   }
 
-  public async saveSession(attributes: object, event: IVoxaEvent): Promise<void> {
+  public async saveSession(attributes: IBag, event: IVoxaEvent): Promise<void> {
     const dialogFlowEvent = event as DialogFlowEvent;
     const serializedData = JSON.stringify(attributes);
     dialogFlowEvent.conv.contexts.set("attributes", 10000, { attributes: serializedData });

--- a/src/platforms/dialog-flow/DialogFlowSession.ts
+++ b/src/platforms/dialog-flow/DialogFlowSession.ts
@@ -13,6 +13,7 @@ import { IVoxaSession } from "../../VoxaEvent";
 
 export class DialogFlowSession implements IVoxaSession {
   public attributes: any;
+  public outputAttributes: object = {};
   public new: boolean;
   public sessionId: string;
   public contexts: Contexts;
@@ -29,19 +30,19 @@ export class DialogFlowSession implements IVoxaSession {
       return {};
     }
 
-    const context: Context<Parameters>|undefined = this.contexts.model;
+    const context: Context<Parameters>|undefined = this.contexts.attributes;
     if (!context) {
       return {};
     }
 
-    if (_.isString(context.parameters.model)) {
-      return JSON.parse(context.parameters.model);
+    if (_.isString(context.parameters.attributes)) {
+      return JSON.parse(context.parameters.attributes);
     }
 
-    if (_.isObject(context.parameters.model)) {
-      return context.parameters.model;
+    if (_.isObject(context.parameters.attributes)) {
+      return context.parameters.attributes;
     }
 
-    return context.parameters.model;
+    return context.parameters.attributes;
   }
 }

--- a/src/plugins/state-flow.ts
+++ b/src/plugins/state-flow.ts
@@ -8,13 +8,13 @@ import { IVoxaReply } from "../VoxaReply";
 
 export function register(skill: VoxaApp) {
   skill.onRequestStarted((voxaEvent: IVoxaEvent) => {
-    const fromState = voxaEvent.session.new ? "entry" : voxaEvent.model.state || "entry";
-    voxaEvent.model.flow = [fromState];
+    const fromState = voxaEvent.session.new ? "entry" : voxaEvent.session.attributes.state || "entry";
+    voxaEvent.session.outputAttributes.flow = [fromState];
   });
 
   skill.onAfterStateChanged((voxaEvent: IVoxaEvent, reply: IVoxaReply, transition: ITransition) => {
-    voxaEvent.model.flow = voxaEvent.model.flow || [];
-    voxaEvent.model.flow.push(transition.to);
+    voxaEvent.session.outputAttributes.flow = voxaEvent.session.outputAttributes.flow || [];
+    voxaEvent.session.outputAttributes.flow.push(transition.to);
     return transition;
   });
 }

--- a/test/Gadgets.spec.ts
+++ b/test/Gadgets.spec.ts
@@ -208,7 +208,6 @@ describe("Gadgets", () => {
     expect(_.get(reply, "response.outputSpeech.ssml")).to.include("Thanks for playing with echo buttons.");
     expect(reply.response.reprompt).to.be.undefined;
     expect(_.get(reply, "response.directives[0].type")).to.equal("GameEngine.StopInputHandler");
-    expect(_.get(reply, "sessionAttributes.originatingRequestId")).to.equal("originatingRequestId");
     expect(_.get(reply, "sessionAttributes.state")).to.equal("die");
     expect(reply.response.shouldEndSession).to.equal(true);
   });

--- a/test/alexa/AlexaReply.spec.ts
+++ b/test/alexa/AlexaReply.spec.ts
@@ -54,7 +54,7 @@ describe("AlexaReply", () => {
         },
         shouldEndSession: false,
       },
-      // sessionAttributes: {},
+      sessionAttributes: {},
       version: "1.0",
     });
   });
@@ -69,6 +69,7 @@ describe("AlexaReply", () => {
         },
         shouldEndSession: false,
       },
+      sessionAttributes: {},
       version: "1.0",
     });
   });
@@ -84,6 +85,7 @@ describe("AlexaReply", () => {
         },
         shouldEndSession: true,
       },
+      sessionAttributes: {},
       version: "1.0",
     });
   });
@@ -138,6 +140,7 @@ describe("AlexaReply", () => {
           },
         },
       },
+      sessionAttributes: {},
       version: "1.0",
     });
   });
@@ -186,6 +189,7 @@ describe("AlexaReply", () => {
         },
         shouldEndSession: true,
       },
+      sessionAttributes: {},
       version: "1.0",
     });
   });

--- a/test/botframework/BotFrameworkEvent.spec.ts
+++ b/test/botframework/BotFrameworkEvent.spec.ts
@@ -72,4 +72,11 @@ describe("BotFrameworkEvent", () => {
       userId: "LTSO852UtAD",
     });
   });
+
+  it("builds the session", () => {
+    const rawEvent = prepIncomingMessage(_.cloneDeep(require("../requests/botframework/StaintIntent.json")));
+    const event = new BotFrameworkEvent(rawEvent, {}, {}, storage);
+    expect(event.session.attributes).to.be.a("object");
+    expect(event.session.outputAttributes).to.be.a("object");
+  });
 });

--- a/test/create-server.spec.ts
+++ b/test/create-server.spec.ts
@@ -63,6 +63,7 @@ describe("createServer", () => {
         },
         shouldEndSession: true,
       },
+      sessionAttributes: {},
       version: "1.0",
     });
 

--- a/test/plugins/auto-load.spec.js
+++ b/test/plugins/auto-load.spec.js
@@ -57,7 +57,7 @@ describe('AutoLoad plugin', () => {
         expect(spy.lastCall.args[0].intent.name).to.equal('LaunchIntent');
         expect(result.response.outputSpeech.ssml).to.include("Hello! Good");
         expect(result.sessionAttributes.state).to.equal('die');
-        expect(result.sessionAttributes.user.Id).to.equal(1);
+        expect(result.sessionAttributes.model.user.Id).to.equal(1);
       });
   });
 

--- a/test/plugins/state-flow.spec.ts
+++ b/test/plugins/state-flow.spec.ts
@@ -26,6 +26,7 @@ describe("StateFlow plugin", () => {
         state: "secondState",
       },
       new: false,
+      outputAttributes: {},
     };
 
     states = {
@@ -46,7 +47,7 @@ describe("StateFlow plugin", () => {
     stateFlow.register(skill);
 
     const result = await skill.execute(event, new AlexaReply());
-    expect(event.model.flow).to.deep.equal(["secondState", "initState", "die"]);
+    expect(event.session.outputAttributes.flow).to.deep.equal(["secondState", "initState", "die"]);
   });
 
   it("should not crash on null transition", async () => {
@@ -60,6 +61,6 @@ describe("StateFlow plugin", () => {
     event.intent.name = "OtherIntent";
 
     const result = await skill.execute(event, new AlexaReply());
-    expect(event.model.flow).to.deep.equal(["fourthState"]);
+    expect(event.session.outputAttributes.flow).to.deep.equal(["fourthState"]);
   });
 });

--- a/test/requests/dialog-flow/helpIntent.json
+++ b/test/requests/dialog-flow/helpIntent.json
@@ -13,10 +13,10 @@
         "name": "projects/project/agent/sessions/1528150043739/contexts/actions_capability_audio_output"
       },
       {
-        "name": "projects/project/agent/sessions/1528150043739/contexts/model",
+        "name": "projects/project/agent/sessions/1528150043739/contexts/attributes",
         "lifespanCount": 99999,
         "parameters": {
-          "model": "{\"key\":\"value\"}"
+          "attributes": "{\"key\":\"value\"}"
         }
       },
       {


### PR DESCRIPTION
This change is a proposal to slightly modify how we do serialization/deserialization.
Previously we'd stick everything into the attributes in the same object level as the model. This would lead to unexpected behavior if the model was cleared or the risk of model data and plugin data clobbering one another.

This change introduces two paths to data serialization/deserialization.

1) Models. Models continue to use there serialize method. `fromEvent` has been renamed `deserialize` and is now *passed* the model data, rather than making the implementor dig it out of session.attributes itself. Besides making the interface more obvious, this could allow us to in the future inject other middleware that knows how to retrieve additional model data (e.g. from a database) w/o the models needing the change. Deserialize now goes into the reply attributes under the `model` key.

2) The session now has an attribute called `outputAttributes`. This is where non-model things put their attributes (e.g. plugins, or where the state goes). It's now a bit clearer that this is separate from the model. Of course plugins can still clobber each other, but at least the model, the most common thing for developers to access, is isolated now.