### PR TITLE
Fixes a bug that prevented the SM from using the global intent handlers

### DIFF
--- a/src/StateMachine/StateMachine.ts
+++ b/src/StateMachine/StateMachine.ts
@@ -77,7 +77,12 @@ export class StateMachine {
       throw new Error("State Machine Recursion Error");
     }
 
-    const transition = await this.stateTransition(fromState, voxaEvent, reply);
+    const transition = await this.stateTransition(
+      fromState,
+      voxaEvent,
+      reply,
+      recursions,
+    );
 
     let sysTransition = await this.checkOnUnhandledState(
       voxaEvent,
@@ -111,6 +116,7 @@ export class StateMachine {
     fromState: string,
     voxaEvent: IVoxaIntentEvent,
     reply: IVoxaReply,
+    recursions: number,
   ): Promise<ITransition> {
     try {
       if (fromState === "entry") {
@@ -127,6 +133,15 @@ export class StateMachine {
         );
       }
     } catch (error) {
+      /*
+       * Returning to the global handler here only makes sense if we didn't already made that,
+       * meaning that it could only be done in the first recussion. There's tests covering this scenarion
+       * in tests/States.spec.ts
+       */
+      if (fromState !== "entry" && recursions < 1) {
+        return this.stateTransition("entry", voxaEvent, reply, recursions);
+      }
+
       if (error instanceof UnknownState) {
         if (!this.onUnhandledStateCallback) {
           throw new Error(`${voxaEvent.intent.name} went unhandled`);
@@ -134,6 +149,8 @@ export class StateMachine {
 
         return this.onUnhandledStateCallback(voxaEvent, voxaEvent.intent.name);
       }
+
+      throw error;
     }
 
     await this.runOnBeforeStateChanged(voxaEvent, reply);

--- a/src/platforms/alexa/directives.ts
+++ b/src/platforms/alexa/directives.ts
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2018 Rain Agency <contact@rain.agency>
+ * Author: Rain Agency <contact@rain.agency>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 import { dialog, Directive, interfaces, Response, ui } from "ask-sdk-model";
 import * as _ from "lodash";
 import { IDirective } from "../../directives";

--- a/test/States.spec.ts
+++ b/test/States.spec.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2018 Rain Agency <contact@rain.agency>
+ * Author: Rain Agency <contact@rain.agency>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { expect } from "chai";
+import * as _ from "lodash";
+import { AlexaPlatform, IVoxaEvent, VoxaApp } from "../src";
+import { AlexaRequestBuilder } from "./tools";
+import { variables } from "./variables";
+import { views } from "./views";
+
+describe("States", () => {
+  let voxaApp: VoxaApp;
+  let alexaSkill: AlexaPlatform;
+  let rb: AlexaRequestBuilder;
+
+  beforeEach(() => {
+    rb = new AlexaRequestBuilder();
+    voxaApp = new VoxaApp({ variables, views });
+
+    voxaApp.onIntent("HelpIntent", {
+      flow: "yield",
+      sayp: "Help",
+      to: "entry",
+    });
+
+    voxaApp.onState(
+      "helpSettings",
+      {
+        flow: "yield",
+        sayp: "question",
+        to: "entry",
+      },
+      "YesIntent",
+    );
+
+    voxaApp.onState(
+      "helpSettings",
+      (voxaEvent: IVoxaEvent) => {
+        return {
+          flow: "yield",
+          sayp: "question",
+          to: "entry",
+        };
+      },
+      "NoIntent",
+    );
+
+    alexaSkill = new AlexaPlatform(voxaApp);
+  });
+
+  it("should correctly transition to the global handler after failling to find a correct handler", async () => {
+    const helpRequest = rb.getIntentRequest("AMAZON.HelpIntent");
+    _.set(helpRequest, "session.new", false);
+    _.set(helpRequest, "session.attributes", {
+      model: {},
+      state: "helpSettings",
+    });
+    const reply = await alexaSkill.execute(helpRequest);
+    expect(reply.response.shouldEndSession).to.be.false;
+    expect(reply.sessionAttributes).to.deep.equal({
+      model: {},
+      state: "entry",
+    });
+    expect(reply.response.outputSpeech.ssml).to.equal("<speak>Help</speak>");
+  });
+});


### PR DESCRIPTION
The current behavior only allowed for global intent handlers to be called when the intent event came from a new session or the current state was entry. This was a regression that meant the following code wouldn't call the `HelpIntent` handler in the following example when in the `helpSettings` state.

This PR fixes that

```ts
    voxaApp.onIntent("HelpIntent", {
      flow: "yield",
      sayp: "Help",
      to: "entry",
    });

    voxaApp.onState(
      "helpSettings",
      {
        flow: "yield",
        sayp: "question",
        to: "entry",
      },
      "YesIntent",
    );

    voxaApp.onState(
      "helpSettings",
      (voxaEvent: IVoxaEvent) => {
        return {
          flow: "yield",
          sayp: "question",
          to: "entry",
        };
      },
      "NoIntent",
    );
```